### PR TITLE
Update gradle.properties for Java17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Gradle 8 needs Java 17, and Java 17 removed some params

ref: https://github.com/umer0586/SensorServer/blob/v5.0.0/gradle/wrapper/gradle-wrapper.properties

ref: https://gitlab.com/fdroid/fdroiddata/-/jobs/4804502932#L319

Fixed directly in the F-Droid recipe for now: https://gitlab.com/fdroid/fdroiddata/-/commit/b8ea88726347a153db79c42a612f271733dc0385